### PR TITLE
Fix to failed when call `require()`

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ink-progress-spinner",
   "version": "1.0.0",
   "description": "Progress spinner component for Ink",
-  "main": "index.js",
+  "main": "src/index.js",
   "author": "y0za",
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
## 概要

package.json の main が存在しないファイルを指しているため，
require() に失敗するのを修正しました．


以下，再現手順とエラーログです．

1. `$ npm install https://github.com/y0za/ink-progress-spinner`

2. 

```js
const { spinners, ProgressSpinner } = require('ink-progress-spinner');
```

```
Error: Cannot find module 'ink-progress-spinner'
    at Function.Module._resolveFilename (module.js:485:15)
    at Function.Module._load (module.js:437:25)
    at Module.require (module.js:513:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/home/maxmellon/work/ghq/github.com/MaxMEllon/ita/lib/components/list.js:3:39)
    at Module._compile (module.js:569:30)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:503:32)
    at tryModuleLoad (module.js:466:12)
    at Function.Module._load (module.js:458:3)
```